### PR TITLE
fix: Default for permission presets

### DIFF
--- a/oarepo_model_builder_workflows/datatypes/components/workflow.py
+++ b/oarepo_model_builder_workflows/datatypes/components/workflow.py
@@ -37,7 +37,7 @@ class WorkflowComponent(DataTypeComponent):
 
     def before_model_prepare(self, datatype, *, context, **kwargs):
         if datatype.root.profile in {"record", "files", "draft_files"}:  # or ~any service with permission presets
-            datatype.definition["permissions"]["presets"] = ["workflow"]
+            datatype.definition["permissions"].setdefault("presets", ["workflow"])
 
         if datatype.root.profile == "record":
             fields = datatype.definition["record"].setdefault("fields", {})

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = oarepo-model-builder-workflows
-version = 1.0.3
+version = 1.0.4
 description =
 authors = Mirek Simek <miroslav.simek@cesnet.cz>
 readme = README.md


### PR DESCRIPTION
This commit fixes default value for permission presets - if there is no preset from user, use the "workflow" one - never overwrite